### PR TITLE
Add phone code selector page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # example
 
 Simple demo project using Vue 3, Element Plus and Vue Router.
-It provides a navigation bar and a sample country selector page.
+It provides a navigation bar and two sample selector pages:
+
+- Country selector with name and flag.
+- Phone code selector showing dialing code and flag.
 
 ## Recommended IDE Setup
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Simple demo project using Vue 3, Element Plus and Vue Router.
 It provides a navigation bar and two sample selector pages:
 
-- Country selector with name and flag.
-- Phone code selector showing dialing code and flag.
+- Country selector with name and a country flag image.
+- Phone code selector showing dialing code and a country flag image.
 
 ## Recommended IDE Setup
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,10 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router';
 import Home from '../view/Home.vue';
 import CountrySelect from '../view/countries/CountrySelect.vue';
+import PhoneCodeSelect from '../view/countries/PhoneCodeSelect.vue';
 
 const routes = [
     { path: '/', component: Home },
-    { path: '/country', component: CountrySelect }
+    { path: '/country', component: CountrySelect },
+    { path: '/phone-code', component: PhoneCodeSelect }
 ];
 
 const router = createRouter({

--- a/src/view/Nav.vue
+++ b/src/view/Nav.vue
@@ -3,6 +3,7 @@
   <el-menu mode="horizontal" router background-color="#545c64" text-color="#fff" active-text-color="#ffd04b">
     <el-menu-item index="/">首页</el-menu-item>
     <el-menu-item index="/country">国家选择器</el-menu-item>
+    <el-menu-item index="/phone-code">区号选择器</el-menu-item>
   </el-menu>
 </template>
 

--- a/src/view/countries/CountrySelect.vue
+++ b/src/view/countries/CountrySelect.vue
@@ -6,10 +6,13 @@
       <el-option
           v-for="c in countries"
           :key="c.iso"
-          :label="`${flag(c.iso)} ${c.zh || c.name}`"
+          :label="c.zh || c.name"
           :value="c.iso"
       >
-        <span>{{ flag(c.iso) }} {{ c.zh || c.name }} ({{ c.code }})</span>
+        <span class="option">
+          <img class="flag" :src="c.flag" :alt="c.name" />
+          <span>{{ c.zh || c.name }} ({{ c.code }})</span>
+        </span>
       </el-option>
     </el-select>
   </div>
@@ -20,16 +23,19 @@ import countries from './data/countries-with-zh.js';
 import { ref } from 'vue';
 
 const selectedCountry = ref(null);
-
-function flag(iso) {
-  return [...iso.toUpperCase()]
-      .map(ch => String.fromCodePoint(127397 + ch.charCodeAt()))
-      .join('');
-}
 </script>
 
 <style scoped>
 .el-select {
   margin-top: 1rem;
+}
+.option {
+  display: flex;
+  align-items: center;
+}
+.flag {
+  width: 20px;
+  height: 15px;
+  margin-right: 0.5rem;
 }
 </style>

--- a/src/view/countries/PhoneCodeSelect.vue
+++ b/src/view/countries/PhoneCodeSelect.vue
@@ -6,10 +6,13 @@
       <el-option
           v-for="c in countries"
           :key="c.iso"
-          :label="`${flag(c.iso)} ${c.code}`"
+          :label="c.code"
           :value="c.code"
       >
-        <span>{{ flag(c.iso) }} {{ c.code }} ({{ c.zh || c.name }})</span>
+        <span class="option">
+          <img class="flag" :src="c.flag" :alt="c.name" />
+          <span>{{ c.code }} ({{ c.zh || c.name }})</span>
+        </span>
       </el-option>
     </el-select>
   </div>
@@ -20,16 +23,19 @@ import countries from './data/countries-with-zh.js';
 import { ref } from 'vue';
 
 const selectedCode = ref(null);
-
-function flag(iso) {
-  return [...iso.toUpperCase()]
-      .map(ch => String.fromCodePoint(127397 + ch.charCodeAt()))
-      .join('');
-}
 </script>
 
 <style scoped>
 .el-select {
   margin-top: 1rem;
+}
+.option {
+  display: flex;
+  align-items: center;
+}
+.flag {
+  width: 20px;
+  height: 15px;
+  margin-right: 0.5rem;
 }
 </style>

--- a/src/view/countries/PhoneCodeSelect.vue
+++ b/src/view/countries/PhoneCodeSelect.vue
@@ -1,0 +1,35 @@
+// PhoneCodeSelect.vue
+<template>
+  <div style="padding: 2rem">
+    <h2>选择手机区号</h2>
+    <el-select v-model="selectedCode" placeholder="请选择区号" filterable style="width: 300px">
+      <el-option
+          v-for="c in countries"
+          :key="c.iso"
+          :label="`${flag(c.iso)} ${c.code}`"
+          :value="c.code"
+      >
+        <span>{{ flag(c.iso) }} {{ c.code }} ({{ c.zh || c.name }})</span>
+      </el-option>
+    </el-select>
+  </div>
+</template>
+
+<script setup>
+import countries from './data/countries-with-zh.js';
+import { ref } from 'vue';
+
+const selectedCode = ref(null);
+
+function flag(iso) {
+  return [...iso.toUpperCase()]
+      .map(ch => String.fromCodePoint(127397 + ch.charCodeAt()))
+      .join('');
+}
+</script>
+
+<style scoped>
+.el-select {
+  margin-top: 1rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- create `PhoneCodeSelect.vue` for dialing code selection
- add route and nav link for the new selector
- document selector pages in the README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854fd779edc83319017d6088fde968e