### PR TITLE
Add phone input with mask

### DIFF
--- a/src/components/PhoneNumberInput.vue
+++ b/src/components/PhoneNumberInput.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="phone-input">
+    <span v-if="code" class="prefix">{{ code }}</span>
+    <input
+      :placeholder="maskPlaceholder"
+      :value="formattedValue"
+      @input="handleInput"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  mask: { type: [String, Array], default: '' },
+  code: { type: String, default: '' }
+});
+const emit = defineEmits(['update:modelValue']);
+
+const digits = ref(props.modelValue);
+
+watch(() => props.modelValue, val => {
+  digits.value = val || '';
+});
+
+const masks = computed(() => Array.isArray(props.mask) ? props.mask : [props.mask]);
+
+const maxDigits = computed(() => {
+  return Math.max(...masks.value.map(m => (m.match(/#/g) || []).length), 0);
+});
+
+function applyMask(value) {
+  const maskArr = masks.value;
+  if (!maskArr.length) return value;
+  const digitStr = value.replace(/\D/g, '');
+  const target = maskArr.find(m => digitStr.length <= (m.match(/#/g) || []).length) || maskArr[maskArr.length - 1];
+  let out = '';
+  let i = 0;
+  for (const ch of target) {
+    if (ch === '#') {
+      if (i < digitStr.length) out += digitStr[i++];
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+const formattedValue = computed(() => applyMask(digits.value));
+
+const maskPlaceholder = computed(() => masks.value[0] || '');
+
+function handleInput(e) {
+  const onlyDigits = e.target.value.replace(/\D/g, '');
+  digits.value = onlyDigits.slice(0, maxDigits.value);
+  emit('update:modelValue', digits.value);
+}
+</script>
+
+<style scoped>
+.phone-input {
+  display: flex;
+  align-items: center;
+  margin-top: 1rem;
+}
+.phone-input .prefix {
+  margin-right: 0.5rem;
+  color: #333;
+}
+.phone-input input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+</style>

--- a/src/view/countries/PhoneCodeSelect.vue
+++ b/src/view/countries/PhoneCodeSelect.vue
@@ -26,7 +26,7 @@
 
 <script setup>
 import countries from './data/countries-with-zh.js';
-import { ref, computed } from 'vue';
+import { ref, computed, watch } from 'vue';
 import PhoneNumberInput from '../../components/PhoneNumberInput.vue';
 
 const selectedCode = ref(null);
@@ -35,6 +35,10 @@ const phone = ref('');
 const selectedCountry = computed(() =>
   countries.find(c => c.code === selectedCode.value)
 );
+
+watch(selectedCode, () => {
+  phone.value = '';
+});
 </script>
 
 <style scoped>

--- a/src/view/countries/PhoneCodeSelect.vue
+++ b/src/view/countries/PhoneCodeSelect.vue
@@ -15,20 +15,19 @@
         </span>
       </el-option>
     </el-select>
-    <div class="phone-input" v-if="selectedCode">
-      <span class="prefix">{{ selectedCode }}</span>
-      <input
-          :placeholder="currentMask"
-          :value="formattedPhone"
-          @input="onPhoneInput"
-      />
-    </div>
+    <PhoneNumberInput
+        v-if="selectedCode"
+        v-model="phone"
+        :code="selectedCode"
+        :mask="selectedCountry?.mask"
+    />
   </div>
 </template>
 
 <script setup>
 import countries from './data/countries-with-zh.js';
 import { ref, computed } from 'vue';
+import PhoneNumberInput from '../../components/PhoneNumberInput.vue';
 
 const selectedCode = ref(null);
 const phone = ref('');
@@ -36,48 +35,6 @@ const phone = ref('');
 const selectedCountry = computed(() =>
   countries.find(c => c.code === selectedCode.value)
 );
-
-const currentMask = computed(() => {
-  const mask = selectedCountry.value?.mask;
-  if (!mask) return '';
-  return Array.isArray(mask) ? mask[0] : mask;
-});
-
-const maxDigits = computed(() => {
-  const mask = selectedCountry.value?.mask;
-  if (!mask) return Infinity;
-  const masks = Array.isArray(mask) ? mask : [mask];
-  return Math.max(
-    ...masks.map(m => (m.match(/#/g) || []).length)
-  );
-});
-
-function applyMask(value, mask) {
-  if (!mask) return value;
-  const digits = value.replace(/\D/g, '');
-  const masks = Array.isArray(mask) ? mask : [mask];
-  const targetMask =
-    masks.find(m => digits.length <= m.replace(/[^#]/g, '').length) || masks[masks.length - 1];
-  let result = '';
-  let idx = 0;
-  for (const ch of targetMask) {
-    if (ch === '#') {
-      if (idx < digits.length) {
-        result += digits[idx++];
-      }
-    } else {
-      result += ch;
-    }
-  }
-  return result;
-}
-
-const formattedPhone = computed(() => applyMask(phone.value, selectedCountry.value?.mask));
-
-function onPhoneInput(e) {
-  const digits = e.target.value.replace(/\D/g, '');
-  phone.value = digits.slice(0, maxDigits.value);
-}
 </script>
 
 <style scoped>
@@ -94,21 +51,4 @@ function onPhoneInput(e) {
   margin-right: 0.5rem;
 }
 
-.phone-input {
-  margin-top: 1rem;
-  display: flex;
-  align-items: center;
-}
-
-.phone-input .prefix {
-  margin-right: 0.5rem;
-  color: #333;
-}
-
-.phone-input input {
-  flex: 1;
-  padding: 0.5rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-}
 </style>

--- a/src/view/countries/PhoneCodeSelect.vue
+++ b/src/view/countries/PhoneCodeSelect.vue
@@ -15,7 +15,7 @@
         </span>
       </el-option>
     </el-select>
-    <div class="phone-input" v-if="selectedCode" style="margin-top: 1rem">
+    <div class="phone-input" v-if="selectedCode">
       <span class="prefix">{{ selectedCode }}</span>
       <input
           :placeholder="currentMask"
@@ -43,6 +43,15 @@ const currentMask = computed(() => {
   return Array.isArray(mask) ? mask[0] : mask;
 });
 
+const maxDigits = computed(() => {
+  const mask = selectedCountry.value?.mask;
+  if (!mask) return Infinity;
+  const masks = Array.isArray(mask) ? mask : [mask];
+  return Math.max(
+    ...masks.map(m => (m.match(/#/g) || []).length)
+  );
+});
+
 function applyMask(value, mask) {
   if (!mask) return value;
   const digits = value.replace(/\D/g, '');
@@ -66,7 +75,8 @@ function applyMask(value, mask) {
 const formattedPhone = computed(() => applyMask(phone.value, selectedCountry.value?.mask));
 
 function onPhoneInput(e) {
-  phone.value = e.target.value.replace(/\D/g, '');
+  const digits = e.target.value.replace(/\D/g, '');
+  phone.value = digits.slice(0, maxDigits.value);
 }
 </script>
 
@@ -85,11 +95,20 @@ function onPhoneInput(e) {
 }
 
 .phone-input {
+  margin-top: 1rem;
   display: flex;
   align-items: center;
 }
 
 .phone-input .prefix {
   margin-right: 0.5rem;
+  color: #333;
+}
+
+.phone-input input {
+  flex: 1;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 </style>

--- a/src/view/countries/PhoneCodeSelect.vue
+++ b/src/view/countries/PhoneCodeSelect.vue
@@ -15,14 +15,59 @@
         </span>
       </el-option>
     </el-select>
+    <div class="phone-input" v-if="selectedCode" style="margin-top: 1rem">
+      <span class="prefix">{{ selectedCode }}</span>
+      <input
+          :placeholder="currentMask"
+          :value="formattedPhone"
+          @input="onPhoneInput"
+      />
+    </div>
   </div>
 </template>
 
 <script setup>
 import countries from './data/countries-with-zh.js';
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
 const selectedCode = ref(null);
+const phone = ref('');
+
+const selectedCountry = computed(() =>
+  countries.find(c => c.code === selectedCode.value)
+);
+
+const currentMask = computed(() => {
+  const mask = selectedCountry.value?.mask;
+  if (!mask) return '';
+  return Array.isArray(mask) ? mask[0] : mask;
+});
+
+function applyMask(value, mask) {
+  if (!mask) return value;
+  const digits = value.replace(/\D/g, '');
+  const masks = Array.isArray(mask) ? mask : [mask];
+  const targetMask =
+    masks.find(m => digits.length <= m.replace(/[^#]/g, '').length) || masks[masks.length - 1];
+  let result = '';
+  let idx = 0;
+  for (const ch of targetMask) {
+    if (ch === '#') {
+      if (idx < digits.length) {
+        result += digits[idx++];
+      }
+    } else {
+      result += ch;
+    }
+  }
+  return result;
+}
+
+const formattedPhone = computed(() => applyMask(phone.value, selectedCountry.value?.mask));
+
+function onPhoneInput(e) {
+  phone.value = e.target.value.replace(/\D/g, '');
+}
 </script>
 
 <style scoped>
@@ -36,6 +81,15 @@ const selectedCode = ref(null);
 .flag {
   width: 20px;
   height: 15px;
+  margin-right: 0.5rem;
+}
+
+.phone-input {
+  display: flex;
+  align-items: center;
+}
+
+.phone-input .prefix {
   margin-right: 0.5rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- update phone code selector to include a phone number field
- display phone number formatted according to mask from country data

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685501e7c57c8331bd42afab0fda5da6